### PR TITLE
Signal when local candidate gathering is complete

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -19,6 +19,9 @@ candidate_gathering_done_cb(NiceAgent *agent, guint stream_id, gpointer user_dat
   struct rtcdc_transport *transport = peer->transport;
   struct ice_transport *ice = transport->ice;
   ice->gathering_done = TRUE;
+  if (peer->on_candidate) {
+    peer->on_candidate(peer, "", peer->user_data);
+  }
 }
 
 static void


### PR DESCRIPTION
Do so by passing an empty string as the candidate to the on_candidate
callback. This makes it possible to start the candidate gathering,
buffer them and assemble a full SDP with all candidates once they have
all benn gathered.
