### PR TITLE
Don't use BIO for message transfer

### DIFF
--- a/src/dtls.c
+++ b/src/dtls.c
@@ -13,6 +13,7 @@
 #include "common.h"
 #include "dtls.h"
 #include "rtcdc.h"
+#include "sctp.h"
 
 static EVP_PKEY *
 gen_key()
@@ -186,8 +187,8 @@ create_dtls_transport(struct rtcdc_peer_connection *peer,
   BIO_set_mem_eof_return(bio, -1);
   dtls->outgoing_bio = bio;
 
-  dtls->outgoing_queue = g_queue_new();
-  if (dtls->outgoing_queue == NULL)
+  dtls->outgoing_q = g_queue_new();
+  if (dtls->outgoing_q == NULL)
     goto trans_err;
 
   SSL_set_bio(dtls->ssl, dtls->incoming_bio, dtls->outgoing_bio);
@@ -217,4 +218,22 @@ destroy_dtls_transport(struct dtls_transport *dtls)
   SSL_free(dtls->ssl);
   free(dtls);
   dtls = NULL;
+}
+
+void
+flush_dtls_outgoing_bio(struct dtls_transport *dtls)
+{
+  if ((dtls == NULL) || (dtls->outgoing_bio == NULL) || (dtls->outgoing_q == NULL))
+    return;
+
+  char buf[BUFFER_SIZE];
+  while (BIO_ctrl_pending(dtls->outgoing_bio)) {
+    int nbytes = BIO_read(dtls->outgoing_bio, buf, sizeof(buf));
+    if (nbytes > 0) {
+      struct sctp_message *msg = create_sctp_message(buf, nbytes);
+      if (msg != NULL) {
+        g_queue_push_tail(dtls->outgoing_q, msg);
+      }
+    }
+  }
 }

--- a/src/dtls.c
+++ b/src/dtls.c
@@ -186,6 +186,10 @@ create_dtls_transport(struct rtcdc_peer_connection *peer,
   BIO_set_mem_eof_return(bio, -1);
   dtls->outgoing_bio = bio;
 
+  dtls->outgoing_queue = g_queue_new();
+  if (dtls->outgoing_queue == NULL)
+    goto trans_err;
+
   SSL_set_bio(dtls->ssl, dtls->incoming_bio, dtls->outgoing_bio);
 
   EC_KEY *ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);

--- a/src/dtls.h
+++ b/src/dtls.h
@@ -26,6 +26,7 @@ struct dtls_transport {
   SSL *ssl;
   BIO *incoming_bio;
   BIO *outgoing_bio;
+  GQueue *outgoing_queue;
   gboolean handshake_done;
   GMutex dtls_mutex;
 };

--- a/src/dtls.h
+++ b/src/dtls.h
@@ -26,7 +26,7 @@ struct dtls_transport {
   SSL *ssl;
   BIO *incoming_bio;
   BIO *outgoing_bio;
-  GQueue *outgoing_queue;
+  GQueue *outgoing_q;
   gboolean handshake_done;
   GMutex dtls_mutex;
 };
@@ -43,6 +43,9 @@ create_dtls_transport(struct rtcdc_peer_connection *peer,
 
 void
 destroy_dtls_transport(struct dtls_transport *dtls);
+
+void
+flush_dtls_outgoing_bio(struct dtls_transport *dtls);
 
 #ifdef  __cplusplus
 }

--- a/src/ice.c
+++ b/src/ice.c
@@ -62,28 +62,36 @@ data_received_cb(NiceAgent *agent, guint stream_id, guint component_id,
   struct ice_transport *ice = transport->ice;
   struct dtls_transport *dtls = transport->dtls;
   struct sctp_transport *sctp = transport->sctp;
+  char read_buf[BUFFER_SIZE];
   if (!ice->negotiation_done)
     return;
 
   g_mutex_lock(&dtls->dtls_mutex);
   BIO_write(dtls->incoming_bio, buf, len);
+  int nbytes = SSL_read(dtls->ssl, read_buf, sizeof(read_buf));
+  if (!dtls->handshake_done) {
+    if (SSL_is_init_finished(dtls->ssl)) {
+      dtls->handshake_done = TRUE;
+    } else {
+      SSL_do_handshake(dtls->ssl);
+    }
+  }
+
+  if (BIO_ctrl_pending(dtls->outgoing_bio)) {
+    char out_buf[BUFFER_SIZE];
+    while (BIO_ctrl_pending(dtls->outgoing_bio)) {
+      int send_bytes = BIO_read(dtls->outgoing_bio, out_buf, sizeof(out_buf));
+      if (send_bytes > 0) {
+        g_queue_push_tail(dtls->outgoing_queue, create_sctp_message(out_buf, send_bytes));
+      }
+    }
+  }
   g_mutex_unlock(&dtls->dtls_mutex);
 
-  if (!dtls->handshake_done && SSL_is_init_finished(dtls->ssl))
-    dtls->handshake_done = TRUE;
-
-  if (!dtls->handshake_done) {
-    g_mutex_lock(&dtls->dtls_mutex);
-    SSL_do_handshake(dtls->ssl);
-    g_mutex_unlock(&dtls->dtls_mutex);
-  } else {
-    unsigned char buf[BUFFER_SIZE];
-    int nbytes = SSL_read(dtls->ssl, buf, sizeof buf);
-    if (nbytes > 0) {
-      g_mutex_lock(&sctp->sctp_mutex);
-      BIO_write(sctp->incoming_bio, buf, nbytes);
-      g_mutex_unlock(&sctp->sctp_mutex);
-    }
+  if (dtls->handshake_done && (nbytes > 0)) {
+    g_mutex_lock(&sctp->sctp_mutex);
+    g_queue_push_tail(sctp->incoming_q, create_sctp_message(read_buf, nbytes));
+    g_mutex_unlock(&sctp->sctp_mutex);
   }
 }
 
@@ -186,6 +194,25 @@ ice_thread(gpointer user_data)
   // need an external thread to start SCTP when DTLS handshake is done
   char buf[BUFFER_SIZE];
   while (!peer->exit_thread) {
+    g_mutex_lock(&dtls->dtls_mutex);
+    if (!dtls->handshake_done) {
+      if (SSL_is_init_finished(dtls->ssl)) {
+        dtls->handshake_done = TRUE;
+      }
+    }
+
+    while (!g_queue_is_empty(dtls->outgoing_queue)) {
+      struct sctp_message *msg = g_queue_pop_head(dtls->outgoing_queue);
+      g_mutex_unlock(&dtls->dtls_mutex);
+      nice_agent_send(ice->agent, ice->stream_id, 1, msg->len, msg->data);
+      free(msg->data);
+      free(msg);
+      g_mutex_lock(&dtls->dtls_mutex);
+    }
+
+    g_mutex_unlock(&dtls->dtls_mutex);
+    g_usleep(2500);
+
     if (BIO_ctrl_pending(dtls->outgoing_bio) > 0) {
       g_mutex_lock(&dtls->dtls_mutex);
       int nbytes = BIO_read(dtls->outgoing_bio, buf, sizeof buf);

--- a/src/rtcdc.c
+++ b/src/rtcdc.c
@@ -375,13 +375,8 @@ startup_thread(gpointer user_data)
     SSL_set_accept_state(dtls->ssl);
   SSL_do_handshake(dtls->ssl);
 
-  char read_buf[BUFFER_SIZE];
-  while (BIO_ctrl_pending(dtls->outgoing_bio) > 0) {
-    int nbytes = BIO_read(dtls->outgoing_bio, read_buf, sizeof(read_buf));
-    if (nbytes > 0) {
-      g_queue_push_tail(dtls->outgoing_queue, create_sctp_message(read_buf, nbytes));
-    }
-  }
+  flush_dtls_outgoing_bio(dtls);
+
   g_mutex_unlock(&dtls->dtls_mutex);
 
   while (!peer->exit_thread && !dtls->handshake_done)

--- a/src/sctp.c
+++ b/src/sctp.c
@@ -240,12 +240,7 @@ sctp_thread(gpointer user_data)
         g_mutex_unlock(&sctp->sctp_mutex);
         g_mutex_lock(&dtls->dtls_mutex);
         SSL_write(dtls->ssl, msg->data, msg->len);
-        while (BIO_ctrl_pending(dtls->outgoing_bio) > 0) {
-          int dtls_bytes = BIO_read(dtls->outgoing_bio, buf, sizeof(buf));
-          if (dtls_bytes > 0) {
-            g_queue_push_tail(dtls->outgoing_queue, create_sctp_message(buf, dtls_bytes));
-          }
-        }
+        flush_dtls_outgoing_bio(dtls);
         g_mutex_unlock(&dtls->dtls_mutex);
         g_mutex_lock(&sctp->sctp_mutex);
         sent_data = 1;

--- a/src/sctp.c
+++ b/src/sctp.c
@@ -21,7 +21,10 @@ sctp_data_ready_cb(void *reg_addr, void *data, size_t len, uint8_t tos, uint8_t 
 {
   struct sctp_transport *sctp = (struct sctp_transport *)reg_addr;
   g_mutex_lock(&sctp->sctp_mutex);
-  BIO_write(sctp->outgoing_bio, data, len);
+  if (sctp->outgoing_q != NULL)
+    g_queue_push_tail(sctp->outgoing_q, create_sctp_message(data, len));
+  else
+    fprintf(stderr, "Tried to handle sctp message before queue initialization\n");
   g_mutex_unlock(&sctp->sctp_mutex);
   return 0;
 }
@@ -71,7 +74,7 @@ create_sctp_transport(struct rtcdc_peer_connection *peer)
   if (sctp == NULL)
     return NULL;
   peer->transport->sctp = sctp;
-  sctp->local_port = random_integer(10000, 60000);
+  sctp->local_port = 5000; // XXX: Hardcoded for now
 
   if (g_sctp_ref == 0) {
     usrsctp_init(0, sctp_data_ready_cb, NULL);
@@ -86,17 +89,10 @@ create_sctp_transport(struct rtcdc_peer_connection *peer)
     goto trans_err;
   sctp->sock = s;
 
-  BIO *bio = BIO_new(BIO_s_mem());
-  if (bio == NULL)
+  sctp->incoming_q = g_queue_new();
+  sctp->outgoing_q = g_queue_new();
+  if ((sctp->incoming_q == NULL) || (sctp->outgoing_q == NULL))
     goto trans_err;
-  BIO_set_mem_eof_return(bio, -1);
-  sctp->incoming_bio = bio;
-
-  bio = BIO_new(BIO_s_mem());
-  if (bio == NULL)
-    goto trans_err;
-  BIO_set_mem_eof_return(bio, -1);
-  sctp->outgoing_bio = bio;
 
 #ifdef DEBUG_SCTP
   int sd;
@@ -176,8 +172,8 @@ destroy_sctp_transport(struct sctp_transport *sctp)
 
   usrsctp_close(sctp->sock);
   usrsctp_deregister_address(sctp);
-  BIO_free_all(sctp->incoming_bio);
-  BIO_free_all(sctp->outgoing_bio);
+  g_queue_free(sctp->incoming_q);
+  g_queue_free(sctp->outgoing_q);
 #ifdef DEBUG_SCTP
   close(sctp->incoming_stub);
   close(sctp->outgoing_stub);
@@ -196,6 +192,18 @@ destroy_sctp_transport(struct sctp_transport *sctp)
   }
 }
 
+struct sctp_message *
+create_sctp_message(void *data, size_t len)
+{
+  struct sctp_message *msg = malloc(sizeof(struct sctp_message));
+
+  msg->len = len;
+  msg->data = malloc(len);
+  memcpy(msg->data, data, len);
+
+  return msg;
+}
+
 gpointer
 sctp_thread(gpointer user_data)
 {
@@ -204,6 +212,7 @@ sctp_thread(gpointer user_data)
   struct ice_transport *ice = transport->ice;
   struct dtls_transport *dtls = transport->dtls;
   struct sctp_transport *sctp = transport->sctp;
+  int sent_data = 0; // XXX: Only receive once we've sent a packet
 
   while (!peer->exit_thread && !ice->negotiation_done)
     g_usleep(2500);
@@ -217,34 +226,46 @@ sctp_thread(gpointer user_data)
 
   char buf[BUFFER_SIZE];
   while (!peer->exit_thread) {
-    if (BIO_ctrl_pending(sctp->incoming_bio) <= 0 && BIO_ctrl_pending(sctp->outgoing_bio) <= 0)
-      g_usleep(2500);
-
-    if (BIO_ctrl_pending(sctp->incoming_bio) > 0) {
-      g_mutex_lock(&sctp->sctp_mutex);
-      int nbytes = BIO_read(sctp->incoming_bio, buf, sizeof buf);
+    g_mutex_lock(&sctp->sctp_mutex);
+    if (g_queue_is_empty(sctp->outgoing_q) && (sent_data && g_queue_is_empty(sctp->incoming_q))) {
       g_mutex_unlock(&sctp->sctp_mutex);
-#ifdef DEBUG_SCTP
-      send(sctp->incoming_stub, buf, nbytes, 0);
-#endif
-      if (nbytes > 0) {
-        usrsctp_conninput(sctp, buf, nbytes, 0);
-      }
+      g_usleep(500);
+      continue;
     }
 
-    if (BIO_ctrl_pending(sctp->outgoing_bio) > 0) {
-      g_mutex_lock(&sctp->sctp_mutex);
-      int nbytes = BIO_read(sctp->outgoing_bio, buf, sizeof buf);
-      g_mutex_unlock(&sctp->sctp_mutex);
-#ifdef DEBUG_SCTP
-      send(sctp->outgoing_stub, buf, nbytes, 0);
-#endif
-      if (nbytes > 0) {
+    if (!g_queue_is_empty(sctp->outgoing_q)) {
+      struct sctp_message *msg = g_queue_pop_head(sctp->outgoing_q);
+
+      if (msg->len > 0) {
+        g_mutex_unlock(&sctp->sctp_mutex);
         g_mutex_lock(&dtls->dtls_mutex);
-        SSL_write(dtls->ssl, buf, nbytes);
+        SSL_write(dtls->ssl, msg->data, msg->len);
+        while (BIO_ctrl_pending(dtls->outgoing_bio) > 0) {
+          int dtls_bytes = BIO_read(dtls->outgoing_bio, buf, sizeof(buf));
+          if (dtls_bytes > 0) {
+            g_queue_push_tail(dtls->outgoing_queue, create_sctp_message(buf, dtls_bytes));
+          }
+        }
         g_mutex_unlock(&dtls->dtls_mutex);
+        g_mutex_lock(&sctp->sctp_mutex);
+        sent_data = 1;
+        free(msg->data);
       }
+      free(msg);
     }
+
+    if (!g_queue_is_empty(sctp->incoming_q) && sent_data) {
+      struct sctp_message *msg = g_queue_pop_head(sctp->incoming_q);
+      if (msg->len > 0) {
+        g_mutex_unlock(&sctp->sctp_mutex);
+        usrsctp_conninput(sctp, msg->data, msg->len, 0);
+        g_mutex_lock(&sctp->sctp_mutex);
+        free(msg->data);
+      }
+      free(msg);
+    }
+
+    g_mutex_unlock(&sctp->sctp_mutex);
   }
 
   return NULL;

--- a/src/sctp.h
+++ b/src/sctp.h
@@ -24,8 +24,8 @@ struct sctp_message {
 
 struct sctp_transport {
   struct socket *sock;
-  BIO *incoming_bio;
-  BIO *outgoing_bio;
+  GQueue *incoming_q;
+  GQueue *outgoing_q;
   int local_port;
   int remote_port;
   gboolean handshake_done;
@@ -51,6 +51,9 @@ send_sctp_message(struct sctp_transport *sctp,
 
 gpointer
 sctp_thread(gpointer peer);
+
+struct sctp_message *
+create_sctp_message(void *data, size_t len);
 
 #ifdef  __cplusplus
 }


### PR DESCRIPTION
OpenSSL Buffered I/O doesn't preserver message boundaries when using the
memory-based BIO. This means that multiple messages can be returned on a
single call to BIO_read, which is incompatible with DTLS and usrsctp.

This patch changes all cross-thread messaging to use GQueue-based
message queues isntead of memory-backed BIO structures.
