### PR TITLE
fix fingerprint

### DIFF
--- a/src/dtls.c
+++ b/src/dtls.c
@@ -131,10 +131,13 @@ create_dtls_context(const char *common)
 
   char *p = context->fingerprint;
   for (int i = 0; i < len; ++i) {
-    snprintf(p, 3, "%02X:", buf[i]);
+    if (i != len - 1) {
+      snprintf(p, 4, "%02X:", buf[i]);
+    } else {
+      snprintf(p, 3, "%02X", buf[i]);
+    }
     p += 3;
   }
-  *(p - 1) = 0;
 
   if (0) {
 ctx_err:


### PR DESCRIPTION
according to man snprintf:
The functions snprintf() and  vsnprintf()  write  at  most  size  bytes  (including the terminating null byte ('\0')) to str.

before my patch, fingerprint:
a=fingerprint:sha-256 BD

after my patch, fingerprint:
a=fingerprint:sha-256 BD:FE:71:99:D6:C0:27:9A:00:DE:4B:30:13:EC:01:6B:28:D1:40:06:68:65:6C:F5:FC:E4:3B:C7:ED:4B:10:EC